### PR TITLE
Pass cliConfigPath to Language Server

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { LanguageClient, CloseAction, ErrorAction, InitializeError, Message, Rev
 interface LanguageServerConfig {
     readonly lsPath: string;
     readonly cliPath: string;
+    readonly cliConfigPath: string;
     readonly clangdPath: string;
     readonly board: {
         readonly fqbn: string;
@@ -187,8 +188,8 @@ async function startLanguageServer(context: ExtensionContext, config: LanguageSe
 }
 
 async function buildLanguageClient(config: LanguageServerConfig): Promise<LanguageClient> {
-    const { lsPath: command, clangdPath, cliPath, board, flags, env, log } = config;
-    const args = ['-clangd', clangdPath, '-cli', cliPath, '-fqbn', board.fqbn];
+    const { lsPath: command, clangdPath, cliPath, cliConfigPath, board, flags, env, log } = config;
+    const args = ['-clangd', clangdPath, '-cli', cliPath, '-cli-config', cliConfigPath, '-fqbn', board.fqbn];
     if (board.name) {
         args.push('-board-name', board.name);
     }


### PR DESCRIPTION
### Motivation
 Language Server now requires an additional `cliConfigPath`

### Change description
- parse the `cliConfigPath` from parameters and pass it to the executable as a flag

### Additional Notes
Required by [ATL-1247](https://arduino.atlassian.net/browse/ATL-1247)

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] History is clean, commit messages are meaningful.