### PR TITLE
Update check on debug config generation fail

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,7 +114,7 @@ async function startDebug(_: ExtensionContext, config: DebugConfig): Promise<boo
     }
     if (!rawStdout) {
         if (rawStdErr) {
-            if (rawStdErr.indexOf('compiled sketch not found in') !== -1) {
+            if (rawStdErr.toLowerCase().indexOf('compiled sketch not found in') !== -1) {
                 vscode.window.showErrorMessage(`Sketch '${path.basename(config.sketchPath)}' was not compiled. Please compile the sketch and start debugging again.`);
             } else {
                 vscode.window.showErrorMessage(rawStdErr);


### PR DESCRIPTION
When sketch debugging is initiated, the extension runs Arduino CLI to get the debugger configuration information. This information is required to generate the `launch.json` configuration file.

As part of this information is the path to the compiled sketch binary, Arduino CLI checks for the existence of that file, and errors if it is not present (which is usually caused by the user having neglected to compile the sketch):

```
$ arduino-cli version
arduino-cli.exe  Version: git-snapshot Commit: 200d4b4f Date: 2022-02-03T15:48:11Z

$ arduino-cli sketch new /tmp/NotCompiled
Sketch created in: C:\Users\per\AppData\Local\Temp\NotCompiled

$ arduino-cli debug -I -b arduino:samd:mkrzero --format json /tmp/NotCompiled
Error getting Debug info: Compiled sketch not found in C:\Users\per\AppData\Local\Temp\arduino-sketch-B00E82A5EFC5401167B17E3767CC3A00
```

The extension has special handling for this specific common error cause, which is based on a fragile string comparison on the human readable error message. As is the nature of such an approach, a seemingly innocuous capitalization change to the message in the Arduino CLI code base (https://github.com/arduino/arduino-cli/commit/75b9760c965c5f8564b62262a95b2dc9514f3242) broke the check.

The quick fix provided here is making the check case insensitive.

---

**NOTE**: this is not a true fix. The human readable error message string may change at any time, and is guaranteed to change if non-English localization is enabled.

However, it is less broken after this simple change, and the check is not critical, so I think it is still worthwhile.