### PR TITLE
Don't force "format on save" setting on contributors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "tslint.configFile": "./tslint.json",
-  "editor.formatOnSave": true,
   "files.exclude": {
     "**/lib": false
   },


### PR DESCRIPTION
The `editor.formatOnSave` [VS Code setting](https://code.visualstudio.com/docs/getstarted/settings) controls whether file are automatically formatted when saved.

Checking a VS Code workspace settings configuration file into the repository with this setting enabled seems like it would increase the likelihood of contributions being properly formatted. Unfortunately, in this case it does just the opposite. The reason is that no formatter and configuration is provided, so VS Code formats the code according to
whatever formatter and configuration the contributor happens to have set up for TypeScript. In my case, that is [Prettier](https://prettier.io/), the default configuration of which causes extensive formatting changes on save.

This will result in the following scenarios:

- Conscientious contributors waste time reverting unexpected diffs and figuring out how to prevent future such diffs
- Other contributors submit low quality contributions
- Maintainers waste time review contributions with large diffs unrelated to the proposal
- Conscientious maintainers waste time cajoling contributors into removing unrelated changes from their contributions
- Other maintainers allow large unrelated diffs to be introduced into the repository

Ideally, the infrastructure of the project would be set up to enforce standard code style compliance from contributions. But until that happens, it is best to remove this harmful setting.