### PR TITLE
Change terminateProcess.sh permissions to 755

### DIFF
--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -41,7 +41,7 @@ const config = {
             buildFiles: [
                 {
                     path: path.resolve(__dirname, '..', 'dist', 'terminateProcess.sh'),
-                    fileMode: '555'
+                    fileMode: '755'
                 }
             ]
         })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-arduino-tools",
   "private": true,
-  "version": "0.0.2-beta.1",
+  "version": "0.0.2-beta.2",
   "publisher": "arduino",
   "license": "Apache-2.0",
   "author": "Arduino SA",


### PR DESCRIPTION
This seems to be necessary in order to make electron-updater work on MacOS when executing automatic updates.