### PR TITLE
Notify running LS about build complete.

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,11 @@
         "category": "Arduino"
       },
       {
+        "command": "arduino.languageserver.notifyBuildDidComplete",
+        "title": "Notify Build Did Complete",
+        "category": "Arduino"
+      },
+      {
         "command": "arduino.debug.start",
         "title": "Start Debug",
         "category": "Arduino"

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,0 +1,8 @@
+import { NotificationType, DocumentUri } from 'vscode-languageclient';
+
+export interface DidCompleteBuildParams {
+    readonly buildOutputUri: DocumentUri;
+}
+export namespace DidCompleteBuildNotification {
+    export const TYPE = new NotificationType<DidCompleteBuildParams, void>('ino/didCompleteBuild');
+}


### PR DESCRIPTION
New:
 - Exposed the `arduino.languageserver.notifyBuildDidComplete` command that can be called from the IDE2 to set the new build path of the libraries after a verify,
 - Support for the `ino/didCompleteBuild` protocol extension. (See https://github.com/arduino/arduino-language-server/pull/118)

Ref: arduino/arduino-ide#714

Signed-off-by: Akos Kitta <a.kitta@arduino.cc>