### PR TITLE
Can start the LS without real-time diagnostics.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-arduino-tools",
   "private": true,
-  "version": "0.0.2-beta.3",
+  "version": "0.0.2-beta.4",
   "publisher": "arduino",
   "license": "Apache-2.0",
   "author": "Arduino SA",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ interface LanguageServerConfig {
     readonly log?: boolean | string;
     readonly env?: any;
     readonly flags?: string[];
+    readonly realTimeDiagnostics?: boolean;
 }
 
 interface DebugConfig {
@@ -201,6 +202,9 @@ async function buildLanguageClient(config: LanguageServerConfig): Promise<Langua
     const args = ['-clangd', clangdPath, '-cli-daemon-addr', cliDaemonAddr, '-cli-daemon-instance', cliDaemonInstance, '-fqbn', board.fqbn, '-skip-libraries-discovery-on-rebuild'];
     if (board.name) {
         args.push('-board-name', board.name);
+    }
+    if (typeof config.realTimeDiagnostics === 'boolean' && !config.realTimeDiagnostics) {
+        args.push('-no-real-time-diagnostics');
     }
     if (flags && flags.length) {
         args.push(...flags);


### PR DESCRIPTION
Ref: arduino/arduino-language-server#124

Signed-off-by: Akos Kitta <a.kitta@arduino.cc>

The functionality was verified in the IDE2. See https://github.com/arduino/arduino-ide/pull/1107.