### PR TITLE
Can start the LS without an Output channel.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-arduino-tools",
   "private": true,
-  "version": "0.0.2-beta.4",
+  "version": "0.0.2-beta.5",
   "publisher": "arduino",
   "license": "Apache-2.0",
   "author": "Arduino SA",


### PR DESCRIPTION
The Arduino LS can be started without the [`OutputChannel`](https://code.visualstudio.com/api/references/vscode-api#OutputChannel) support.

IDE2 will start the LS with the new `silentOutput: true` option. This should help IDE2's UI. UX-wise, it's no change for the users.

Ref: arduino/arduino-ide#714

Signed-off-by: Akos Kitta <a.kitta@arduino.cc>