### PR TITLE
fix: use CLI config path for debug command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-arduino-tools",
   "private": true,
-  "version": "0.0.2-beta.7",
+  "version": "0.0.2-beta.8",
   "publisher": "arduino",
   "license": "Apache-2.0",
   "author": "Arduino SA",


### PR DESCRIPTION
If the `directories.data` is not the default, debug metadata generation can fail with a false positive missing platform error.

Ref: https://github.com/arduino/arduino-ide/issues/1911

Changes:
 - use the `--config-file` for the `debug -I` command,
 - bumped version for the next release,
 - checked in VSIX to git (**this commit must be dropped from the PR**)

Downstream: https://github.com/arduino/arduino-ide/pull/1975