### PR TITLE
fix(ci): run tests with a `$DISPLAY` for the release build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Test
-        run: yarn test
+        run: xvfb-run yarn test-all
       - name: Package
         run: yarn package
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "vscode-arduino-tools",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Arduino Tools extension for VS Code",
   "license": "Apache-2.0",
   "author": "Arduino SA",


### PR DESCRIPTION
This project has not had integration tests before https://github.com/arduino/vscode-arduino-tools/pull/41. Now, tests run, but they fail on Linux due to the missing X Server or display.

Changes:

 - Run tests with a display
 - Run all tests
 - Bump version to match the next tag