### PR TITLE
feat: flag to limit the thread count used by LS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "vscode-arduino-tools",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Arduino Tools extension for VS Code",
   "license": "Apache-2.0",
   "author": "Arduino SA",
@@ -25,7 +25,7 @@
     "compile-tests": "tsc -p . --outDir lib",
     "format": "prettier --write . && prettier-package-json --write ./package.json",
     "generate": "node ./scripts/generate.js 1.5.1",
-    "postinstall": "node ./scripts/cli 0.35.0-rc.7",
+    "postinstall": "node ./scripts/cli 0.35.2",
     "lint": "eslint src --ext ts",
     "prepackage": "yarn clean && yarn compile && yarn lint && yarn webpack",
     "package": "mkdirp build-artifacts && vsce package --out ./build-artifacts",

--- a/src/ino.ts
+++ b/src/ino.ts
@@ -55,6 +55,10 @@ export interface StartLanguageServerParams {
    * If `true`, the logging is not forwarded to the _Output_ view via the language client.
    */
   readonly silentOutput?: boolean;
+  /**
+   * Number of async workers used by `clangd`. Background index also uses this many workers. If `0`, `clangd` uses all available cores. It's `0` by default.
+   */
+  readonly jobs?: number;
 }
 
 /**
@@ -177,6 +181,7 @@ async function buildLanguageClient(
     flags,
     env,
     log,
+    jobs,
   } = config;
   const args = [
     '-clangd',
@@ -215,6 +220,10 @@ async function buildLanguageClient(
     if (logPath) {
       args.push('-logpath', logPath);
     }
+  }
+  // https://github.com/arduino/arduino-language-server/pull/177
+  if (jobs) {
+    args.push('-jobs', String(jobs));
   }
   const clientOptions: LanguageClientOptions = {
     initializationOptions: {},

--- a/src/test/suite/debug.slow-test.ts
+++ b/src/test/suite/debug.slow-test.ts
@@ -38,7 +38,7 @@ describe('debug (slow)', function () {
   describe('createLaunchConfig', () => {
     it('should create with the required custom board options (USBMode=hwcdc)', async () => {
       const configOptions = 'USBMode=hwcdc';
-      const fqbn = `esp32:esp32:nano_nora:${configOptions}`;
+      const fqbn = `arduino:esp32:nano_nora:${configOptions}`;
       const name = 'the board name';
       const programmer = 'esptool';
       const actual = await createLaunchConfig({
@@ -50,14 +50,14 @@ describe('debug (slow)', function () {
       });
       const expected = {
         name: `${name} (${configOptions},${programmer})`,
-        configId: 'esp32:esp32:nano_nora:USBMode=hwcdc,programmer=esptool',
+        configId: 'arduino:esp32:nano_nora:USBMode=hwcdc,programmer=esptool',
         cwd: '${workspaceRoot}',
         request: 'attach',
         type: 'cortex-debug',
         executable: fromBuildPath('my_sketch.ino.elf'),
         toolchainPrefix: 'xtensa-esp32s3-elf',
         svdFile: fromDataDir(
-          'packages/esp32/hardware/esp32/3.0.0-arduino3/tools/ide-debug/svd/esp32s3.svd'
+          'packages/arduino/hardware/esp32/3.0.0-arduino3r2/tools/ide-debug/svd/esp32s3.svd'
         ),
         objdumpPath: fromDataDir(
           '/packages/esp32/tools/xtensa-esp32s3-elf-gcc/esp-12.2.0_20230208/bin/xtensa-esp32s3-elf-objdump'
@@ -86,7 +86,7 @@ describe('debug (slow)', function () {
     });
 
     it('should fail when the required custom board options are missing', async () => {
-      const fqbn = 'esp32:esp32:nano_nora';
+      const fqbn = 'arduino:esp32:nano_nora';
       const programmer = 'esptool';
       await assert.rejects(
         createLaunchConfig({
@@ -155,7 +155,7 @@ describe('debug (slow)', function () {
 
   it('should build the debug --info arguments', async () => {
     const { file, args } = buildDebugInfoArgs({
-      board: { fqbn: 'arduino:esp32:nano_nora' },
+      board: { fqbn: 'arduino:esp32:nano_nora:USBMode=hwcdc' },
       cliPath: testEnv.cliPath,
       sketchPath,
       cliConfigPath: testEnv.cliConfigPath,
@@ -173,10 +173,8 @@ describe('debug (slow)', function () {
         this.skip();
       }
       await assert.rejects(
-        cliExec(
-          ['debug', '-I', '-b', 'arduino:esp32:nano_nora', sketchPath],
-          locale
-        ),
+        // Can be any arbitrary board that does not have a default programmer defined in the platform. Otherwise, the error does not occur.
+        cliExec(['debug', '-I', '-b', 'arduino:avr:uno', sketchPath], locale),
         (reason) => isMissingProgrammerError(reason)
       );
     })
@@ -188,7 +186,7 @@ describe('debug (slow)', function () {
         'debug',
         '-I',
         '-b',
-        'arduino:esp32:nano_nora',
+        'arduino:esp32:nano_nora:USBMode=hwcdc',
         '-P',
         'unknown',
         sketchPath,

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -92,8 +92,8 @@ async function setup(tracked: typeof temp): Promise<TestEnv> {
   const params: PrepareTestEnvParams = {
     ...testEnv,
     platformsToInstall: [
-      { platform: 'esp32:esp32', version: '3.0.0-arduino3' },
-      { platform: 'arduino:esp32' },
+      { platform: 'arduino:avr' }, // this is an arbitrary core without default programmer set to get the expected error from the CLI with the --programmer value is missing
+      { platform: 'arduino:esp32', version: '3.0.0-arduino3r2' },
       { platform: 'arduino:samd' }, // samd is need to get the tools for the manually (Git) installed core
     ],
     additionalUrls: [

--- a/src/test/testEnv.ts
+++ b/src/test/testEnv.ts
@@ -135,14 +135,11 @@ async function prepareWithCli(params: PrepareTestEnvParams): Promise<void> {
   await cliExec(['core', 'update-index'], cliConfigPath);
   log('Updated index');
   for (const { platform, version } of params.platformsToInstall ?? []) {
-    const args = [
-      'core',
-      'install',
-      version ? `${platform}@${version}` : platform,
-      '--skip-post-install',
-    ];
+    const toInstall = version ? `${platform}@${version}` : platform;
+    log(`Installing ${toInstall}...`);
+    const args = ['core', 'install', toInstall, '--skip-post-install'];
     await cliExec(args, cliConfigPath);
-    log(`Installed ${platform}`);
+    log(`Done. Installed ${platform}`);
   }
   log('Done');
 }


### PR DESCRIPTION
 chore: bump version for the release
 test: use the latest CLI version for testing
 feat(test): improve logging for tests
   - log when core install starts fix(test): regressions due to platform change
   - change core version to `3.0.0-arduino3r2`,
   - the vendor ID is `arduino` and not `esp32` anymore, and
   - use the AVR core for negative tests: it does not have a default programmer set. Hence, the
expected error is not triggered.

Ref: arduino/arduino-language-server#177

----
The VSIX is available [to download](https://github.com/kittaakos/vscode-arduino-tools/raw/arduino/arduino-language-server%23177-VSIX/build-artifacts/vscode-arduino-tools-0.1.2.vsix) from my fork. [Here](https://github.com/arduino/vscode-arduino-tools/compare/arduino/arduino-language-server%23177...kittaakos:arduino/arduino-language-server%23177-VSIX) is the diff against this PR.