### PR TITLE
Fix regression in overriding remapped debug configuration data via `debug_custom.json`

### DIFF
--- a/src/debug.ts
+++ b/src/debug.ts
@@ -306,7 +306,8 @@ async function mergeLaunchConfig(
     (config) => config.configId === configId
   );
   const name = createName(board, programmer);
-  const launchConfig = {
+  // Create base configuration data
+  let launchConfig = {
     configId,
     cwd: '${workspaceRoot}',
     request: 'launch',
@@ -315,17 +316,26 @@ async function mergeLaunchConfig(
     ...(debugInfo.customConfigs
       ? debugInfo.customConfigs[cortexDebug] ?? {}
       : {}),
-    ...(customConfig ? customConfig : {}),
     name,
   };
+
+  // Remap Arduino CLI debug config properties to launch.json keys
   replaceValue('serverPath', 'serverpath', launchConfig);
   replaceValue('server', 'servertype', launchConfig);
   replaceValue('toolchainPath', 'armToolchainPath', launchConfig);
   replaceValue('serverConfiguration.scripts', 'configFiles', launchConfig);
+  // Remove unused Arduino CLI debug config data
   unsetValue(launchConfig, 'customConfigs');
   unsetValue(launchConfig, 'serverConfiguration');
   unsetValue(launchConfig, 'programmer'); // The programmer is not used by the debugger https://github.com/arduino/arduino-cli/pull/2391
   unsetValue(launchConfig, 'toolchain'); // The toolchain is also unused by IDE2 or the cortex-debug VSIX
+
+  // Merge configuration from debug_custom.json
+  launchConfig = {
+    ...launchConfig,
+    ...(customConfig ? customConfig : {}),
+  };
+
   return launchConfig;
 }
 

--- a/src/test/suite/debug.test.ts
+++ b/src/test/suite/debug.test.ts
@@ -144,8 +144,27 @@ describe('debug', () => {
       const actual = await mergeLaunchConfig(
         board,
         programmer,
-        { executable },
-        [{ configId, cwd: 'alma' }]
+        {
+          executable,
+          toolchainPrefix: 'toolchain-prefix',
+          serverPath: 'path/to/server',
+          server: 'openocd',
+          toolchainPath: 'path/to/toolchain',
+          serverConfiguration: {
+            scripts: ['path/to/config-file'],
+          },
+        },
+        [
+          {
+            configId,
+            cwd: 'alma',
+            toolchainPrefix: 'custom-toolchain-prefix',
+            serverpath: '/path/to/custom-server',
+            servertype: 'jlink',
+            armToolchainPath: '/path/to/custom-arm-toolchain',
+            configFiles: ['/path/to/custom-config'],
+          },
+        ]
       );
       assert.deepStrictEqual(actual, {
         configId,
@@ -154,6 +173,11 @@ describe('debug', () => {
         name: 'ABC (p1)',
         request: 'launch',
         type: 'cortex-debug',
+        toolchainPrefix: 'custom-toolchain-prefix',
+        serverpath: '/path/to/custom-server',
+        servertype: 'jlink',
+        armToolchainPath: '/path/to/custom-arm-toolchain',
+        configFiles: ['/path/to/custom-config'],
       });
     });
 

--- a/src/test/suite/debug.test.ts
+++ b/src/test/suite/debug.test.ts
@@ -230,8 +230,11 @@ describe('debug', () => {
         const actual = await mergeLaunchConfig(
           board,
           programmer,
-          { executable },
-          [{ configId, [key]: value }]
+          {
+            executable,
+            [key]: value,
+          },
+          []
         );
         assert.deepStrictEqual(actual, expected);
       })


### PR DESCRIPTION
Some of the data from the [`arduino-cli debug --info`](https://arduino.github.io/arduino-cli/dev/commands/arduino-cli_debug/) output does not match exactly with the `launch.json` format required by the [**Cortex-Debug**](https://github.com/Marus/cortex-debug) VS Code extension used at the Arduino IDE integrated sketch debugger. For this reason, some remapping of the **Arduino CLI** data is required.

The user can adjust the debugger configuration via a debug_custom.json file in the sketch project. The data from this file is merged into the base data provided by `arduino-cli debug --info`. The data from debug_custom.json should override the base data where there is overlap.

During the recent reworking of the debugger configuration generation code (https://github.com/arduino/vscode-arduino-tools/pull/41), a regression was introduced that caused the override to no longer work for the remapped Arduino CLI data. The cause was applying the remapping after merging the `debug_custom.json` data, which resulted in the `debug_custom.json` data being overridden by that subset of the Arduino CLI data.

This was not caught by the project's tests because there was no coverage for overrides. I have added coverage and you can see the test fails when ran on the codebase prior to the patch:

https://github.com/arduino/vscode-arduino-tools/actions/runs/8128174502/job/22213780846?pr=49#step:6:159

The bug is fixed by performing the remapping before merging the `debug_custom.json` data.

Fixes https://github.com/arduino/vscode-arduino-tools/issues/48